### PR TITLE
Added CMake & extern "C"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,6 @@
+idf_component_register(
+    SRCS
+    "zones.c"
+    
+    INCLUDE_DIRS "."
+)

--- a/zones.h
+++ b/zones.h
@@ -5,4 +5,13 @@
  * @param[in]   name   the tz database name for the timezone in question
  * @return             the POSIX string for the timezone in question
  **/
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 const char * micro_tz_db_get_posix_str(const char * name);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
I have added a CMakeLists.txt file to allow the repository to be used as a component in ESP-IDF projects.

As my current project is C++, I have also added extern "C" to zones.h, surrounded by #ifdef macros.